### PR TITLE
Support for Gnome 3.20

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -8,6 +8,7 @@
   "gettext-domain": "gnome-shell-extension-gravatar",
   "shell-version": [
     "3.16",
-    "3.18"
+    "3.18",
+    "3.20"
   ]
 }


### PR DESCRIPTION
[Gnome 3.20 was released](https://www.gnome.org/news/2016/03/gnome-3-20-released/) yesterday.
I just tested and this extension works fine under Gnome 3.20!
