### PR TITLE
Remove warning about anonymous function return value

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -89,6 +89,7 @@ const Extension = new Lang.Class({
         this._userLoop = null;
         log('Timeout waiting for user to initialize');
       }
+      return null;
     }.bind(this), 1000);
   },
 


### PR DESCRIPTION
Hi,

Using:

```sh
gnome-shell --replace &
```

I've got the following:

```sh
Gjs-Message: JS WARNING: [/home/zapashcanon/.local/share/gnome-shell/extensions/gravatar@jr.rlabs.io/extension.js 92]: anonymous function does not always return a value
```

This change fix the warning.

Thanks !