### PR TITLE
remove unnecessary arg

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -136,7 +136,7 @@ const Extension = new Lang.Class({
 
       let fstream = icon.replace(null, false, Gio.FileCreateFlags.NONE, null);
       request.connect('got_chunk', function (msg, chunk) {
-        fstream.write(chunk.get_data(), null, chunk.length);
+        fstream.write(chunk.get_data(), null);
       });
 
       // download file


### PR DESCRIPTION
@length isn't a necessary argument in GJS bindings, and now raises an error (non-fatal) in GJS 1.50